### PR TITLE
Add indicators to streak

### DIFF
--- a/components/game/GameViewer.vue
+++ b/components/game/GameViewer.vue
@@ -2,7 +2,7 @@
   <div
     class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 w-full gap-4"
   >
-    <div class="grid grid-cols-2 xl:grid-cols-3 gap-x-4 gap-y-6">
+    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-4 gap-y-6">
       <StatBadge
         title="Daily Average"
         :value="scoredGames.dailyStreakStats.averageInRangeForFullDay.currentScoredDayWithFallback?.scoreForDisplay || 'Unknown'"
@@ -33,6 +33,10 @@
         :icon-color="getColorForDailyStreak(scoredGames.dailyStreakStats.averageInRangeForFullDay.currentStreak.scoredDays.length)"
         :best="scoredGames.dailyStreakStats.averageInRangeForFullDay.bestStreak.length === scoredGames.dailyStreakStats.averageInRangeForFullDay.currentStreak.scoredDays.length"
         description="average within range"
+        :show-streak-days="true"
+        :streak-stats="scoredGames.dailyStreakStats.averageInRangeForFullDay"
+        :target-score="thresholds.high / 2 + thresholds.low / 2"
+        :is-percentage="false"
       />
       <StatBadge
         title="In Range Streak"
@@ -41,6 +45,10 @@
         :icon-color="getColorForDailyStreak(scoredGames.dailyStreakStats.percentTimeInRangeForFullDay.currentStreak.scoredDays.length)"
         :best="scoredGames.dailyStreakStats.percentTimeInRangeForFullDay.bestStreak.length === scoredGames.dailyStreakStats.percentTimeInRangeForFullDay.currentStreak.scoredDays.length"
         description="at least 80% in range"
+        :show-streak-days="true"
+        :streak-stats="scoredGames.dailyStreakStats.percentTimeInRangeForFullDay"
+        :target-score="80"
+        :is-percentage="true"
       />
       <StatBadge
         title="Nighttime Streak"
@@ -49,6 +57,10 @@
         :icon-color="getColorForDailyStreak(scoredGames.dailyStreakStats.percentTimeInRangeForNights.currentStreak.scoredDays.length)"
         :best="scoredGames.dailyStreakStats.percentTimeInRangeForNights.bestStreak.length === scoredGames.dailyStreakStats.percentTimeInRangeForNights.currentStreak.scoredDays.length"
         description="at least 80% in range"
+        :show-streak-days="true"
+        :streak-stats="scoredGames.dailyStreakStats.percentTimeInRangeForNights"
+        :target-score="80"
+        :is-percentage="true"
       />
       <StatBadge
         title="Morning Streak"
@@ -57,6 +69,10 @@
         :icon-color="getColorForDailyStreak(scoredGames.dailyStreakStats.percentTimeInRangeForMornings.currentStreak.scoredDays.length)"
         :best="scoredGames.dailyStreakStats.percentTimeInRangeForMornings.bestStreak.length === scoredGames.dailyStreakStats.percentTimeInRangeForMornings.currentStreak.scoredDays.length"
         description="at least 80% in range"
+        :show-streak-days="true"
+        :streak-stats="scoredGames.dailyStreakStats.percentTimeInRangeForMornings"
+        :target-score="80"
+        :is-percentage="true"
       />
       <StatBadge
         title="Afternoon Streak"
@@ -65,6 +81,10 @@
         :icon-color="getColorForDailyStreak(scoredGames.dailyStreakStats.percentTimeInRangeForAfternoons.currentStreak.scoredDays.length)"
         :best="scoredGames.dailyStreakStats.percentTimeInRangeForAfternoons.bestStreak.length === scoredGames.dailyStreakStats.percentTimeInRangeForAfternoons.currentStreak.scoredDays.length"
         description="at least 80% in range"
+        :show-streak-days="true"
+        :streak-stats="scoredGames.dailyStreakStats.percentTimeInRangeForAfternoons"
+        :target-score="80"
+        :is-percentage="true"
       />
       <StatBadge
         title="Evening Streak"
@@ -73,6 +93,10 @@
         :icon-color="getColorForDailyStreak(scoredGames.dailyStreakStats.percentTimeInRangeForEvenings.currentStreak.scoredDays.length)"
         :best="scoredGames.dailyStreakStats.percentTimeInRangeForEvenings.bestStreak.length === scoredGames.dailyStreakStats.percentTimeInRangeForEvenings.currentStreak.scoredDays.length"
         description="at least 80% in range"
+        :show-streak-days="true"
+        :streak-stats="scoredGames.dailyStreakStats.percentTimeInRangeForEvenings"
+        :target-score="80"
+        :is-percentage="true"
       />
     </div>
     <LineGraph

--- a/components/global/StatBadge.vue
+++ b/components/global/StatBadge.vue
@@ -22,15 +22,21 @@
         </div>
         <ClientOnly>
           <!-- Show streak days indicator above the value -->
-          <div v-if="showStreakDays && streakStats" class="flex justify-start mb-1">
-            <StreakDaysIndicator 
-              :streak-stats="streakStats" 
+          <div
+            v-if="showStreakDays && streakStats"
+            class="flex justify-start mb-1"
+          >
+            <StreakDaysIndicator
+              :streak-stats="streakStats"
               :target-score="targetScore"
               :is-percentage="isPercentage"
             />
           </div>
           <!-- Use stat-value class with conditional sizing -->
-          <div class="stat-value" :class="{'text-lg': showStreakDays}">
+          <div
+            class="stat-value"
+            :class="{ 'text-lg': showStreakDays }"
+          >
             {{ value }}
           </div>
           <div class="stat-desc">

--- a/components/global/StatBadge.vue
+++ b/components/global/StatBadge.vue
@@ -17,18 +17,27 @@
     </div>
     <div class="stats w-full h-min overflow-hidden bg-base-300">
       <div class="stat min-w-fit">
-        <div class="stat-title">
+        <div class="stat-title mb-1">
           {{ title }}
         </div>
         <ClientOnly>
-          <div class="stat-value">
+          <!-- Show streak days indicator above the value -->
+          <div v-if="showStreakDays && streakStats" class="flex justify-start mb-1">
+            <StreakDaysIndicator 
+              :streak-stats="streakStats" 
+              :target-score="targetScore"
+              :is-percentage="isPercentage"
+            />
+          </div>
+          <!-- Use stat-value class with conditional sizing -->
+          <div class="stat-value" :class="{'text-lg': showStreakDays}">
             {{ value }}
           </div>
           <div class="stat-desc">
             {{ description }}
           </div>
           <template #fallback>
-            <div class="stat-value">
+            <div class="stat-value text-lg">
               Loading...
             </div>
             <div class="stat-desc">
@@ -42,12 +51,21 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{
+import type { DailyStreakStats } from '~/types/dailyStreakStats'
+
+const props = defineProps<{
   title: string
   value: string
   description: string
   icon?: string | undefined
   iconColor?: string | undefined
   best?: boolean | undefined
+  showStreakDays?: boolean
+  streakStats?: DailyStreakStats
+  targetScore?: number
+  isPercentage?: boolean
 }>()
+
+// Provide the title to child components like StreakDaysIndicator
+provide('statBadgeTitle', props.title)
 </script>

--- a/components/global/StreakDaysIndicator.vue
+++ b/components/global/StreakDaysIndicator.vue
@@ -1,0 +1,314 @@
+<template>
+  <div class="flex flex-col items-start streak-component relative">
+    <!-- Days of the week labels -->
+    <div class="flex space-x-1 text-xs opacity-70">
+      <div 
+        v-for="(day, index) in recentDays" 
+        :key="`label-${index}`" 
+        class="w-5 h-5 flex items-center justify-center"
+      >
+        {{ getDayLabel(day.date) }}
+      </div>
+    </div>
+    
+    <!-- Status indicators with tooltips -->
+    <div class="flex space-x-1 streak-indicators-container">
+      <div 
+        v-for="(day, index) in recentDays" 
+        :key="`indicator-${index}`" 
+        class="w-5 h-5 flex items-center justify-center relative group"
+        :class="{'border border-base-300 rounded-full': day.isPending}"
+        @mouseenter="showTooltip($event, index, day)"
+        @mouseleave="hideTooltip"
+        aria-haspopup="true"
+        :aria-label="getDayTooltipLabel(day)"
+      >
+        <Icon 
+          v-if="day.success === true" 
+          name="ph:check-circle-fill" 
+          class="text-success" 
+          size="18" 
+        />
+        <Icon 
+          v-else-if="day.success === false" 
+          name="ph:x-circle-fill" 
+          class="text-error" 
+          size="18" 
+        />
+        <Icon 
+          v-else-if="day.isPending" 
+          name="ph:clock-fill" 
+          class="text-base-content opacity-50" 
+          size="18" 
+        />
+        <Icon 
+          v-else 
+          name="ph:question-fill" 
+          class="text-base-content opacity-50" 
+          size="18" 
+        />
+      </div>
+    </div>
+  </div>
+  
+  <!-- Teleport tooltip to document body -->
+  <ClientOnly>
+    <Teleport to="body">
+      <div 
+        v-show="tooltipVisible"
+        class="fixed pointer-events-none z-[9999]"
+        :style="tooltipStyle"
+        role="tooltip"
+        aria-live="polite"
+      >
+        <div class="unovis-style-tooltip">
+          <span class="font-semibold">{{ tooltipDate }}</span>: 
+          {{ tooltipText }}
+        </div>
+      </div>
+    </Teleport>
+  </ClientOnly>
+</template>
+
+<script setup lang="ts">
+import { nextTick, onMounted, onBeforeUnmount, ref } from 'vue'
+import type { ScoredDay } from '~/types/scoredDay'
+import type { DailyStreakStats } from '~/types/dailyStreakStats'
+import type { CurrentDayStatus } from '~/types/constants'
+import { EveningTiming, NightTiming, MorningTiming, AfternoonTiming, FullDayTiming } from '~/types/timing'
+
+const props = defineProps<{
+  streakStats: DailyStreakStats
+  targetScore?: number
+  isPercentage?: boolean
+}>()
+
+// Get the title from the parent StatBadge component
+const title = inject('statBadgeTitle', '')
+
+// Tooltip state
+const tooltipVisible = ref(false)
+const tooltipStyle = ref({
+  top: '0px',
+  left: '0px',
+  transform: 'translate(-50%, -100%)'
+})
+const tooltipDate = ref('')
+const tooltipText = ref('')
+
+// Show tooltip when hovering over indicator
+const showTooltip = (event: MouseEvent, index: number, day: any) => {
+  // Get element position
+  const target = event.currentTarget as HTMLElement
+  const rect = target.getBoundingClientRect()
+  
+  // Calculate position (in the middle of the element, above it)
+  const left = rect.left + (rect.width / 2)
+  const top = rect.top
+  
+  // Update tooltip data
+  tooltipDate.value = formatDate(day.date)
+  tooltipText.value = day.scoreDisplay
+  tooltipStyle.value = {
+    top: `${top}px`,
+    left: `${left}px`,
+    transform: 'translate(-50%, -100%)'
+  }
+  
+  // Show tooltip
+  tooltipVisible.value = true
+}
+
+// Hide tooltip
+const hideTooltip = () => {
+  tooltipVisible.value = false
+}
+
+// Get the 5 most recent days from the scored days
+const recentDays = computed(() => {
+  try {
+    // Basic safety checks
+    if (!props.streakStats || !props.streakStats.scoredDays) {
+      return getEmptyDays(5)
+    }
+
+    // Get timezone-aware now and today
+    const now = new Date()
+    const currentHour = now.getHours()
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    
+    // Get sorted scored days
+    let days = [...props.streakStats.scoredDays]
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+      .slice(0, 5)
+    
+    // Process streak days
+    days = days.map(day => {
+      const targetValue = props.targetScore || 80
+      
+      const dayDate = new Date(day.date)
+      dayDate.setHours(0, 0, 0, 0)
+      const isToday = dayDate.getTime() === today.getTime()
+      
+      let isSuccess = null
+      let scoreDisplay = ''
+      let isPending = false
+      
+      if (day.scoreForDisplay) {
+        if (props.isPercentage) {
+          isSuccess = day.score >= targetValue
+          scoreDisplay = day.scoreForDisplay + '%'
+          
+          // Handle pending status for today based on time periods
+          if (isToday) {
+            // Determine which timing period we're dealing with based on the title
+            const titleLower = title.toLowerCase()
+            
+            if (titleLower.includes('evening') && currentHour < EveningTiming.startHour) {
+              isSuccess = null
+              isPending = true
+              scoreDisplay = `After ${EveningTiming.formattedStartTime}`
+            }
+            
+            else if (titleLower.includes('night') && currentHour < NightTiming.startHour) {
+              isSuccess = null
+              isPending = true
+              scoreDisplay = `After ${NightTiming.formattedStartTime}`
+            }
+            
+            else if (titleLower.includes('morning') && currentHour < MorningTiming.startHour) {
+              isSuccess = null
+              isPending = true
+              scoreDisplay = `After ${MorningTiming.formattedStartTime}`
+            }
+            
+            else if (titleLower.includes('afternoon') && currentHour < AfternoonTiming.startHour) {
+              isSuccess = null
+              isPending = true
+              scoreDisplay = `After ${AfternoonTiming.formattedStartTime}`
+            }
+          }
+        } else {
+          isSuccess = day.passesThreshold === true
+          scoreDisplay = day.scoreForDisplay + ' mg/dL'
+        }
+      } else {
+        scoreDisplay = 'Unknown'
+      }
+      
+      return {
+        date: day.date,
+        success: isSuccess,
+        isPending,
+        scoreDisplay
+      }
+    }).reverse()
+
+    // Check if we need to add today as a pending day
+    const hasToday = days.some(day => {
+      const d = new Date(day.date)
+      d.setHours(0, 0, 0, 0)
+      return d.getTime() === today.getTime()
+    })
+    
+    // Add pending today if not present and needed
+    if (!hasToday && props.isPercentage) {
+        // Determine which timing period we're dealing with
+        const titleLower = title.toLowerCase()
+        let pendingMessage = 'Waiting for data'
+        
+        if (titleLower.includes('evening')) {
+          pendingMessage = `After ${EveningTiming.formattedStartTime}`
+        } else if (titleLower.includes('night')) {
+          pendingMessage = `After ${NightTiming.formattedStartTime}`
+        } else if (titleLower.includes('morning')) {
+          pendingMessage = `After ${MorningTiming.formattedStartTime}`
+        } else if (titleLower.includes('afternoon')) {
+          pendingMessage = `After ${AfternoonTiming.formattedStartTime}`
+        }
+        
+        days.push({
+            date: today,
+            success: null,
+            isPending: true,
+            scoreDisplay: pendingMessage
+        })
+    }
+    
+    // Fill empty slots if needed
+    while (days.length < 5) {
+      days.unshift({
+        date: new Date(), 
+        success: null,
+        isPending: false,
+        scoreDisplay: 'No data'
+      })
+    }
+    
+    return days
+  } catch (error) {
+    console.error('Error in recentDays computed property:', error)
+    return getEmptyDays(5)
+  }
+})
+
+// Helper function to get empty days
+function getEmptyDays(count) {
+  const days = []
+  for (let i = 0; i < count; i++) {
+    days.push({
+      date: new Date(),
+      success: null,
+      isPending: false,
+      scoreDisplay: 'No data'
+    })
+  }
+  return days
+}
+
+// Get a short day label (M, T, W, T, F, S, S)
+const getDayLabel = (date: Date) => {
+  try {
+    const d = new Date(date)
+    const days = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+    return days[d.getDay()]
+  } catch (e) {
+    return ''
+  }
+}
+
+// Format date for tooltip display
+const formatDate = (date: Date) => {
+  try {
+    if (!date) return ''
+    const d = new Date(date)
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  } catch (e) {
+    return ''
+  }
+}
+
+// Get tooltip label for aria-label
+const getDayTooltipLabel = (day: any) => {
+  try {
+    return `${formatDate(day.date)}: ${day.scoreDisplay}`
+  } catch (e) {
+    return 'Day information'
+  }
+}
+</script>
+
+<style scoped>
+.unovis-style-tooltip {
+  padding: 6px 10px;
+  background-color: oklch(0.243535 0 0); 
+  color: #fff; 
+  border-radius: 4px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+  margin-bottom: 8px;
+  max-width: 250px;
+}
+</style> 

--- a/components/global/StreakDaysIndicator.vue
+++ b/components/global/StreakDaysIndicator.vue
@@ -2,59 +2,59 @@
   <div class="flex flex-col items-start streak-component relative">
     <!-- Days of the week labels -->
     <div class="flex space-x-1 text-xs opacity-70">
-      <div 
-        v-for="(day, index) in recentDays" 
-        :key="`label-${index}`" 
+      <div
+        v-for="(day, index) in recentDays"
+        :key="`label-${index}`"
         class="w-5 h-5 flex items-center justify-center"
       >
         {{ getDayLabel(day.date) }}
       </div>
     </div>
-    
+
     <!-- Status indicators with tooltips -->
     <div class="flex space-x-1 streak-indicators-container">
-      <div 
-        v-for="(day, index) in recentDays" 
-        :key="`indicator-${index}`" 
+      <div
+        v-for="(day, index) in recentDays"
+        :key="`indicator-${index}`"
         class="w-5 h-5 flex items-center justify-center relative group"
-        :class="{'border border-base-300 rounded-full': day.isPending}"
-        @mouseenter="showTooltip($event, index, day)"
-        @mouseleave="hideTooltip"
+        :class="{ 'border border-base-300 rounded-full': day.isPending }"
         aria-haspopup="true"
         :aria-label="getDayTooltipLabel(day)"
+        @mouseenter="showTooltip($event, index, day)"
+        @mouseleave="hideTooltip"
       >
-        <Icon 
-          v-if="day.success === true" 
-          name="ph:check-circle-fill" 
-          class="text-success" 
-          size="18" 
+        <Icon
+          v-if="day.success === true"
+          name="ph:check-circle-fill"
+          class="text-success"
+          size="18"
         />
-        <Icon 
-          v-else-if="day.success === false" 
-          name="ph:x-circle-fill" 
-          class="text-error" 
-          size="18" 
+        <Icon
+          v-else-if="day.success === false"
+          name="ph:x-circle-fill"
+          class="text-error"
+          size="18"
         />
-        <Icon 
-          v-else-if="day.isPending" 
-          name="ph:clock-fill" 
-          class="text-base-content opacity-50" 
-          size="18" 
+        <Icon
+          v-else-if="day.isPending"
+          name="ph:clock-fill"
+          class="text-base-content opacity-50"
+          size="18"
         />
-        <Icon 
-          v-else 
-          name="ph:question-fill" 
-          class="text-base-content opacity-50" 
-          size="18" 
+        <Icon
+          v-else
+          name="ph:question-fill"
+          class="text-base-content opacity-50"
+          size="18"
         />
       </div>
     </div>
   </div>
-  
+
   <!-- Teleport tooltip to document body -->
   <ClientOnly>
     <Teleport to="body">
-      <div 
+      <div
         v-show="tooltipVisible"
         class="fixed pointer-events-none z-[9999]"
         :style="tooltipStyle"
@@ -62,7 +62,7 @@
         aria-live="polite"
       >
         <div class="unovis-style-tooltip">
-          <span class="font-semibold">{{ tooltipDate }}</span>: 
+          <span class="font-semibold">{{ tooltipDate }}</span>:
           {{ tooltipText }}
         </div>
       </div>
@@ -71,11 +71,17 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onMounted, onBeforeUnmount, ref } from 'vue'
-import type { ScoredDay } from '~/types/scoredDay'
+import { ref } from 'vue'
 import type { DailyStreakStats } from '~/types/dailyStreakStats'
-import type { CurrentDayStatus } from '~/types/constants'
-import { EveningTiming, NightTiming, MorningTiming, AfternoonTiming, FullDayTiming } from '~/types/timing'
+import { EveningTiming, NightTiming, MorningTiming, AfternoonTiming } from '~/types/timing'
+
+// Define a type for day objects
+interface DayStatus {
+  date: Date
+  success: boolean | null
+  isPending: boolean
+  scoreDisplay: string
+}
 
 const props = defineProps<{
   streakStats: DailyStreakStats
@@ -91,30 +97,30 @@ const tooltipVisible = ref(false)
 const tooltipStyle = ref({
   top: '0px',
   left: '0px',
-  transform: 'translate(-50%, -100%)'
+  transform: 'translate(-50%, -100%)',
 })
 const tooltipDate = ref('')
 const tooltipText = ref('')
 
 // Show tooltip when hovering over indicator
-const showTooltip = (event: MouseEvent, index: number, day: any) => {
+const showTooltip = (event: MouseEvent, index: number, day: DayStatus) => {
   // Get element position
   const target = event.currentTarget as HTMLElement
   const rect = target.getBoundingClientRect()
-  
+
   // Calculate position (in the middle of the element, above it)
   const left = rect.left + (rect.width / 2)
   const top = rect.top
-  
+
   // Update tooltip data
   tooltipDate.value = formatDate(day.date)
   tooltipText.value = day.scoreDisplay
   tooltipStyle.value = {
     top: `${top}px`,
     left: `${left}px`,
-    transform: 'translate(-50%, -100%)'
+    transform: 'translate(-50%, -100%)',
   }
-  
+
   // Show tooltip
   tooltipVisible.value = true
 }
@@ -137,131 +143,137 @@ const recentDays = computed(() => {
     const currentHour = now.getHours()
     const today = new Date()
     today.setHours(0, 0, 0, 0)
-    
+
     // Get sorted scored days
     let days = [...props.streakStats.scoredDays]
       .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
       .slice(0, 5)
-    
+
     // Process streak days
-    days = days.map(day => {
+    days = days.map((day) => {
       const targetValue = props.targetScore || 80
-      
+
       const dayDate = new Date(day.date)
       dayDate.setHours(0, 0, 0, 0)
       const isToday = dayDate.getTime() === today.getTime()
-      
+
       let isSuccess = null
       let scoreDisplay = ''
       let isPending = false
-      
+
       if (day.scoreForDisplay) {
         if (props.isPercentage) {
           isSuccess = day.score >= targetValue
           scoreDisplay = day.scoreForDisplay + '%'
-          
+
           // Handle pending status for today based on time periods
           if (isToday) {
             // Determine which timing period we're dealing with based on the title
             const titleLower = title.toLowerCase()
-            
+
             if (titleLower.includes('evening') && currentHour < EveningTiming.startHour) {
               isSuccess = null
               isPending = true
               scoreDisplay = `After ${EveningTiming.formattedStartTime}`
             }
-            
+
             else if (titleLower.includes('night') && currentHour < NightTiming.startHour) {
               isSuccess = null
               isPending = true
               scoreDisplay = `After ${NightTiming.formattedStartTime}`
             }
-            
+
             else if (titleLower.includes('morning') && currentHour < MorningTiming.startHour) {
               isSuccess = null
               isPending = true
               scoreDisplay = `After ${MorningTiming.formattedStartTime}`
             }
-            
+
             else if (titleLower.includes('afternoon') && currentHour < AfternoonTiming.startHour) {
               isSuccess = null
               isPending = true
               scoreDisplay = `After ${AfternoonTiming.formattedStartTime}`
             }
           }
-        } else {
+        }
+        else {
           isSuccess = day.passesThreshold === true
           scoreDisplay = day.scoreForDisplay + ' mg/dL'
         }
-      } else {
+      }
+      else {
         scoreDisplay = 'Unknown'
       }
-      
+
       return {
         date: day.date,
         success: isSuccess,
         isPending,
-        scoreDisplay
+        scoreDisplay,
       }
     }).reverse()
 
     // Check if we need to add today as a pending day
-    const hasToday = days.some(day => {
+    const hasToday = days.some((day) => {
       const d = new Date(day.date)
       d.setHours(0, 0, 0, 0)
       return d.getTime() === today.getTime()
     })
-    
+
     // Add pending today if not present and needed
     if (!hasToday && props.isPercentage) {
-        // Determine which timing period we're dealing with
-        const titleLower = title.toLowerCase()
-        let pendingMessage = 'Waiting for data'
-        
-        if (titleLower.includes('evening')) {
-          pendingMessage = `After ${EveningTiming.formattedStartTime}`
-        } else if (titleLower.includes('night')) {
-          pendingMessage = `After ${NightTiming.formattedStartTime}`
-        } else if (titleLower.includes('morning')) {
-          pendingMessage = `After ${MorningTiming.formattedStartTime}`
-        } else if (titleLower.includes('afternoon')) {
-          pendingMessage = `After ${AfternoonTiming.formattedStartTime}`
-        }
-        
-        days.push({
-            date: today,
-            success: null,
-            isPending: true,
-            scoreDisplay: pendingMessage
-        })
+      // Determine which timing period we're dealing with
+      const titleLower = title.toLowerCase()
+      let pendingMessage = 'Waiting for data'
+
+      if (titleLower.includes('evening')) {
+        pendingMessage = `After ${EveningTiming.formattedStartTime}`
+      }
+      else if (titleLower.includes('night')) {
+        pendingMessage = `After ${NightTiming.formattedStartTime}`
+      }
+      else if (titleLower.includes('morning')) {
+        pendingMessage = `After ${MorningTiming.formattedStartTime}`
+      }
+      else if (titleLower.includes('afternoon')) {
+        pendingMessage = `After ${AfternoonTiming.formattedStartTime}`
+      }
+
+      days.push({
+        date: today,
+        success: null,
+        isPending: true,
+        scoreDisplay: pendingMessage,
+      })
     }
-    
+
     // Fill empty slots if needed
     while (days.length < 5) {
       days.unshift({
-        date: new Date(), 
+        date: new Date(),
         success: null,
         isPending: false,
-        scoreDisplay: 'No data'
+        scoreDisplay: 'No data',
       })
     }
-    
+
     return days
-  } catch (error) {
+  }
+  catch (error) {
     console.error('Error in recentDays computed property:', error)
     return getEmptyDays(5)
   }
 })
 
 // Helper function to get empty days
-function getEmptyDays(count) {
-  const days = []
+function getEmptyDays(count: number): DayStatus[] {
+  const days: DayStatus[] = []
   for (let i = 0; i < count; i++) {
     days.push({
       date: new Date(),
       success: null,
       isPending: false,
-      scoreDisplay: 'No data'
+      scoreDisplay: 'No data',
     })
   }
   return days
@@ -273,7 +285,8 @@ const getDayLabel = (date: Date) => {
     const d = new Date(date)
     const days = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
     return days[d.getDay()]
-  } catch (e) {
+  }
+  catch {
     return ''
   }
 }
@@ -284,16 +297,18 @@ const formatDate = (date: Date) => {
     if (!date) return ''
     const d = new Date(date)
     return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-  } catch (e) {
+  }
+  catch {
     return ''
   }
 }
 
 // Get tooltip label for aria-label
-const getDayTooltipLabel = (day: any) => {
+const getDayTooltipLabel = (day: DayStatus) => {
   try {
     return `${formatDate(day.date)}: ${day.scoreDisplay}`
-  } catch (e) {
+  }
+  catch {
     return 'Day information'
   }
 }
@@ -302,8 +317,8 @@ const getDayTooltipLabel = (day: any) => {
 <style scoped>
 .unovis-style-tooltip {
   padding: 6px 10px;
-  background-color: oklch(0.243535 0 0); 
-  color: #fff; 
+  background-color: oklch(0.243535 0 0);
+  color: #fff;
   border-radius: 4px;
   font-size: 0.75rem;
   white-space: nowrap;
@@ -311,4 +326,4 @@ const getDayTooltipLabel = (day: any) => {
   margin-bottom: 8px;
   max-width: 250px;
 }
-</style> 
+</style>

--- a/types/timing.ts
+++ b/types/timing.ts
@@ -17,7 +17,7 @@ export const FullDayTiming: Timing = {
   startMinutes: 0,
   endHour: 23,
   endMinutes: 59,
-  formattedStartTime: '12AM'
+  formattedStartTime: '12AM',
 }
 
 export const NightTiming: Timing = {
@@ -28,7 +28,7 @@ export const NightTiming: Timing = {
   startMinutes: 0,
   endHour: 5,
   endMinutes: 59,
-  formattedStartTime: '12AM'
+  formattedStartTime: '12AM',
 }
 
 export const MorningTiming: Timing = {
@@ -39,7 +39,7 @@ export const MorningTiming: Timing = {
   startMinutes: 0,
   endHour: 11,
   endMinutes: 59,
-  formattedStartTime: '6AM'
+  formattedStartTime: '6AM',
 }
 
 export const AfternoonTiming: Timing = {
@@ -50,7 +50,7 @@ export const AfternoonTiming: Timing = {
   startMinutes: 0,
   endHour: 17,
   endMinutes: 59,
-  formattedStartTime: '12PM'
+  formattedStartTime: '12PM',
 }
 
 export const EveningTiming: Timing = {
@@ -61,7 +61,7 @@ export const EveningTiming: Timing = {
   startMinutes: 0,
   endHour: 23,
   endMinutes: 59,
-  formattedStartTime: '6PM'
+  formattedStartTime: '6PM',
 }
 
 export const AllTimings: Timing[] = [

--- a/types/timing.ts
+++ b/types/timing.ts
@@ -6,6 +6,7 @@ export type Timing = {
   startMinutes: number
   endHour: number
   endMinutes: number
+  formattedStartTime: string
 }
 
 export const FullDayTiming: Timing = {
@@ -16,9 +17,10 @@ export const FullDayTiming: Timing = {
   startMinutes: 0,
   endHour: 23,
   endMinutes: 59,
+  formattedStartTime: '12AM'
 }
 
-export const NightTiming = {
+export const NightTiming: Timing = {
   id: 1,
   icon: 'ph:moon-stars',
   title: 'Night',
@@ -26,9 +28,10 @@ export const NightTiming = {
   startMinutes: 0,
   endHour: 5,
   endMinutes: 59,
+  formattedStartTime: '12AM'
 }
 
-export const MorningTiming = {
+export const MorningTiming: Timing = {
   id: 2,
   icon: 'ph:sun-horizon',
   title: 'Morning',
@@ -36,9 +39,10 @@ export const MorningTiming = {
   startMinutes: 0,
   endHour: 11,
   endMinutes: 59,
+  formattedStartTime: '6AM'
 }
 
-export const AfternoonTiming = {
+export const AfternoonTiming: Timing = {
   id: 3,
   icon: 'ph:sun',
   title: 'Afternoon',
@@ -46,9 +50,10 @@ export const AfternoonTiming = {
   startMinutes: 0,
   endHour: 17,
   endMinutes: 59,
+  formattedStartTime: '12PM'
 }
 
-export const EveningTiming = {
+export const EveningTiming: Timing = {
   id: 4,
   icon: 'ph:cloud-sun',
   title: 'Evening',
@@ -56,6 +61,7 @@ export const EveningTiming = {
   startMinutes: 0,
   endHour: 23,
   endMinutes: 59,
+  formattedStartTime: '6PM'
 }
 
 export const AllTimings: Timing[] = [


### PR DESCRIPTION
First go at adding indicators for the past 5 days to the streak badges: it gives a good idea of how well you did in the past few days in addition to the streak.

![image](https://github.com/user-attachments/assets/1a0629f2-30a1-4721-9683-a75c1494170e)

This is not perfect -- especially the `titleLower.includes('afternoon')` (and similar) in the tooltip. 

I have read the CLA Document and I hereby sign the CLA