### PR TITLE
Add total average and total percent time in range stats components

### DIFF
--- a/components/game/GameViewer.vue
+++ b/components/game/GameViewer.vue
@@ -8,6 +8,8 @@
       <GameAverageInRangeDailyStreak />
       <GamePercentTimeInRangeDailyStreak />
       <StatTotalTimeInRange />
+      <StatTotalAverage />
+      <StatTotalPercentTimeInRange />
     </div>
     <div class="md:col-span-2 grid grid-cols-1 gap-4">
       <ViewerWeeklyStreaks />

--- a/components/stat/StatTotalAverage.vue
+++ b/components/stat/StatTotalAverage.vue
@@ -3,7 +3,7 @@
     title="Total average"
     :value="value"
     icon-color="text-accent"
-    description="across all data"
+    description="throughout selected duration"
   />
 </template>
 

--- a/components/stat/StatTotalAverage.vue
+++ b/components/stat/StatTotalAverage.vue
@@ -1,0 +1,22 @@
+<template>
+  <StatBadge
+    title="Total average"
+    :value="value"
+    icon-color="text-accent"
+    description="across all data"
+  />
+</template>
+
+<script setup lang="ts">
+import { scoreRecordsByAverageGlucose } from '~/utils/scoring/averageGlucoseValue/averageGlucoseValue'
+
+const nuxtApp = useNuxtApp()
+const glucoseValues = nuxtApp.$glucoseValues
+const { getGlucoseValueWithUnit } = useDisplaySettings()
+
+const value = computed(() => {
+  if (!glucoseValues.value.length) return 'N/A'
+  const avg = scoreRecordsByAverageGlucose(glucoseValues.value)
+  return getGlucoseValueWithUnit(avg)
+})
+</script>

--- a/components/stat/StatTotalPercentTimeInRange.vue
+++ b/components/stat/StatTotalPercentTimeInRange.vue
@@ -3,7 +3,7 @@
     title="Total % time in range"
     :value="value"
     icon-color="text-accent"
-    description="across all data"
+    description="throughout selected duration"
     is-percentage
   />
 </template>

--- a/components/stat/StatTotalPercentTimeInRange.vue
+++ b/components/stat/StatTotalPercentTimeInRange.vue
@@ -1,0 +1,24 @@
+<template>
+  <StatBadge
+    title="Total % time in range"
+    :value="value"
+    icon-color="text-accent"
+    description="across all data"
+    is-percentage
+  />
+</template>
+
+<script setup lang="ts">
+import { scoreRecordsByPercentTimeInRange } from '~/utils/scoring/percentTimeInRange/percentTimeInRange'
+import { cleanPercentForDisplay } from '~/utils/formatting/percentFormatting'
+
+const nuxtApp = useNuxtApp()
+const glucoseValues = nuxtApp.$glucoseValues
+const thresholds = nuxtApp.$thresholds
+
+const value = computed(() => {
+  if (!glucoseValues.value.length) return 'N/A'
+  const percent = scoreRecordsByPercentTimeInRange(glucoseValues.value, thresholds.value)
+  return `${cleanPercentForDisplay(percent)}%`
+})
+</script>


### PR DESCRIPTION
- Introduced `StatTotalAverage` and `StatTotalPercentTimeInRange` components to display overall average glucose and percentage of time in range.
- Updated `GameViewer` to include the new stat components for enhanced data visualization.